### PR TITLE
Add Limited Hand Function page meta title and description

### DIFF
--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -13,6 +13,10 @@ class CategoryController extends Controller
 {
     private const LHF_PARENT_SLUG = 'limited-hand-function';
 
+    private const LHF_META_TITLE = 'Limited Hand Function | Bodypoint';
+
+    private const LHF_META_DESCRIPTION = 'Bodypoint\'s Limited Hand Function portfolio: belts, harnesses, joystick handles, and positioning supports engineered for users with limited grip, dexterity, or one-handed function.';
+
     /** Client-defined sub-category display order on the LHF parent page. */
     private const LHF_SUB_CATEGORY_SLUG_ORDER = [
         'belts-with-duralatch',
@@ -55,6 +59,8 @@ class CategoryController extends Controller
                     'subcategory' => $subcategory,
                     'category' => $category,
                     'productGroups' => $this->getLimitedHandFunctionProductGroups($subcategory),
+                    'pageTitle' => self::LHF_META_TITLE,
+                    'metaDescription' => self::LHF_META_DESCRIPTION,
                 ]);
             }
 

--- a/resources/views/category.blade.php
+++ b/resources/views/category.blade.php
@@ -1,5 +1,8 @@
 <x-mainpage-layout>
-    @section('title', $category['name'] ?? '' . ' - ' . config('app.name', 'Bodypoint'))
+    @section('title', $pageTitle ?? (($category['name'] ?? '') . ' - ' . config('app.name', 'Bodypoint')))
+    @if (!empty($metaDescription))
+        @section('meta_description', $metaDescription)
+    @endif
     <section class="py-5">
         <div class="ctm-container">
             <?php if(isset($error)){ echo $error; }else{ ?>

--- a/resources/views/layouts/mainpage.blade.php
+++ b/resources/views/layouts/mainpage.blade.php
@@ -10,6 +10,9 @@
     @endif
 
     <title>@yield('title', config('app.name', 'Bodypoint'))</title>
+    @hasSection('meta_description')
+        <meta name="description" content="@yield('meta_description')">
+    @endif
     <link rel="icon" type="image/png" sizes="32x32" href="{{ asset(Config::get('bodypoint.fav')) }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ asset(Config::get('bodypoint.fav')) }}">
 


### PR DESCRIPTION
Set SEO meta title and description for the Limited Hand Function category page. Add meta description support to the main layout; other category pages unchanged.