### PR TITLE
Fix LHF sub-category filter links using database slugs

### DIFF
--- a/resources/views/category.blade.php
+++ b/resources/views/category.blade.php
@@ -19,7 +19,7 @@
             <div class="prodct-Category my-[15px] md:my-[30px]">
                 <div class="category-sub-cat">
                     @if ($subcategory->isNotEmpty())
-                        <x-subcat-left-menu :subcategory="$subcategory" :categoryName="$category['name']" />
+                        <x-subcat-left-menu :subcategory="$subcategory" :categoryName="$category['name']" :parentSlug="$category['slug']" />
                     @endif
                     <x-category-left-menu :categories="$categories" />
                     {{-- <x-product-left-menu  :products="$products"/> --}}

--- a/resources/views/components/subcat-left-menu.blade.php
+++ b/resources/views/components/subcat-left-menu.blade.php
@@ -9,9 +9,8 @@ $sortedSubcategory  = collect($subcategory)->sortBy('name')->values()->all();
        @foreach ($sortedSubcategory as $cat)
 
        @php
-        $formattedSubCategory = str_replace(' ', '-', strtolower(strip_tags(str_replace('-', '_', $cat['name']))));
-        $formattedCategory = !empty($categoryName) ? str_replace(' ', '-', strtolower(strip_tags(str_replace('-', '_', $categoryName)))) : '';
-        $finalSlug = !empty($formattedCategory) ? $formattedCategory . '/' . $formattedSubCategory : $formattedSubCategory;
+        $parentSlug = $parentSlug ?? '';
+        $finalSlug = $parentSlug !== '' ? $parentSlug . '/' . ($cat['slug'] ?? '') : ($cat['slug'] ?? '');
        @endphp
 
           <div class="border border-[#ECECEC] rounded-[5px] p-[10px] flex gap-[15px] mb-[10px]">


### PR DESCRIPTION
Use category slug from the database for sub-category sidebar links instead of formatting names manually. Fixes "No Category Found" for sub-categories with special characters like & and ™.