### PR TITLE
Add date range filter for Sync Orders and Sync Quotes

### DIFF
--- a/app/Console/Commands/FetchOrderHistory.php
+++ b/app/Console/Commands/FetchOrderHistory.php
@@ -12,7 +12,7 @@ use Carbon\Carbon;
 
 class FetchOrderHistory extends Command
 {
-    protected $signature = 'fetch:order-history {customer?}';
+    protected $signature = 'fetch:order-history {customer?} {--from=} {--to=}';
     protected $description = 'Fetch order history from external API';
 
     public function handle()
@@ -21,8 +21,7 @@ class FetchOrderHistory extends Command
         Log::info("[$cronName] Cron started");
 
         $url = 'OrderHistory';
-        $dateFrom = now()->subHours(24)->toIso8601String();
-        $dateTo   = now()->endOfDay()->toIso8601String();
+        [$dateFrom, $dateTo] = $this->resolveDateRange();
 
         $customer = $this->argument('customer') ?? null;
 
@@ -41,6 +40,33 @@ class FetchOrderHistory extends Command
         } catch (\Exception $e) {
             Log::error("[$cronName] Cron failed: " . $e->getMessage(), ['trace' => $e->getTraceAsString()]);
         }
+    }
+
+    /**
+     * Use --from/--to when provided; otherwise default to last 24 hours.
+     *
+     * @return array{0: string, 1: string}
+     */
+    protected function resolveDateRange(): array
+    {
+        $fromOption = $this->option('from');
+        $toOption = $this->option('to');
+
+        if (!empty($fromOption) && !empty($toOption)) {
+            $dateFrom = Carbon::parse($fromOption)->startOfDay();
+            $dateTo = Carbon::parse($toOption)->endOfDay();
+
+            if ($dateFrom->gt($dateTo)) {
+                [$dateFrom, $dateTo] = [$dateTo->copy()->startOfDay(), $dateFrom->copy()->endOfDay()];
+            }
+
+            return [$dateFrom->toIso8601String(), $dateTo->toIso8601String()];
+        }
+
+        return [
+            now()->subHours(24)->toIso8601String(),
+            now()->endOfDay()->toIso8601String(),
+        ];
     }
 
     protected function storeOrders($orders, $cronName)

--- a/resources/views/order.blade.php
+++ b/resources/views/order.blade.php
@@ -45,8 +45,37 @@
                         </div>
                     </div>
                 </form>
-                <a href="{{ route('sync-account', getCustomerId()) }}"
-                                class="py-2.5 px-5 text-sm font-medium text-white focus:outline-none bg-[#FF9119] rounded-full border border-[#FF9119] focus:z-10 focus:ring-4 focus:ring-[#FF9119]/40 flex gap-3 items-center hover:bg-[#FF9119]/80 justify-center w-full sm:w-[145px]">Sync Orders</a>
+                <form action="{{ route('sync-account', getCustomerId()) }}" method="get" class="mt-4 mb-2">
+                    <div class="grid gap-4 sm:gap-6 mb-4 lg:grid-cols-3 items-end">
+                        <div>
+                            <label for="sync_from" class="block mb-2 text-sm font-medium text-gray-900">Sync From Date:</label>
+                            <div class="relative">
+                                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                                    <x-icons.date />
+                                </div>
+                                <input name="sync_from" id="sync_from" type="text" datepicker datepicker-format="mm/dd/yyyy" datepicker-max-date="{{ now()->format('m/d/Y') }}"
+                                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5"
+                                    placeholder="Select sync start date" value="{{ request('sync_from', now()->subDay()->format('m/d/Y')) }}" required>
+                            </div>
+                        </div>
+                        <div>
+                            <label for="sync_to" class="block mb-2 text-sm font-medium text-gray-900">Sync To Date:</label>
+                            <div class="relative">
+                                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                                    <x-icons.date />
+                                </div>
+                                <input name="sync_to" id="sync_to" type="text" datepicker datepicker-format="mm/dd/yyyy" datepicker-max-date="{{ now()->format('m/d/Y') }}"
+                                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5"
+                                    placeholder="Select sync end date" value="{{ request('sync_to', now()->format('m/d/Y')) }}" required>
+                            </div>
+                        </div>
+                        <div class="flex items-center gap-2 flex-wrap">
+                            <button type="submit"
+                                class="py-2.5 px-5 text-sm font-medium text-white focus:outline-none bg-[#FF9119] rounded-full border border-[#FF9119] focus:z-10 focus:ring-4 focus:ring-[#FF9119]/40 flex gap-3 items-center hover:bg-[#FF9119]/80 justify-center w-full sm:w-[145px]">Sync Orders</button>
+                        </div>
+                    </div>
+                    <p class="text-xs text-gray-500 mb-2">Select a date range to sync order statuses from Syspro for this account.</p>
+                </form>
                 <div class="relative overflow-x-auto sm:rounded-2xl mt-5 md:mt-10" id="order_list">
                     <x-cart.order-list :order="$order" />
                 </div>

--- a/resources/views/quotes/index.blade.php
+++ b/resources/views/quotes/index.blade.php
@@ -70,8 +70,37 @@
                         </div>
                     </div>
                 </form>
-                <a href="{{ route('sync-account', getCustomerId()) }}"
-                    class="py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-full border border-[#000000] hover:bg-[#00838f] hover:border-[#027480] hover:text-[#fff] focus:z-10 focus:ring-4 focus:ring-gray-100 flex gap-3 items-center justify-center w-full sm:w-[145px]">Sync Quotes</a>
+                <form action="{{ route('sync-account', getCustomerId()) }}" method="get" class="mt-4 mb-2">
+                    <div class="lg:grid gap-6 mb-4 lg:grid-cols-3 items-end">
+                        <div>
+                            <label for="sync_from" class="block mb-2 text-sm font-medium text-gray-900">Sync From Date:</label>
+                            <div class="relative">
+                                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                                    <x-icons.date />
+                                </div>
+                                <input name="sync_from" id="sync_from" type="text" datepicker datepicker-format="mm/dd/yyyy" datepicker-max-date="{{ now()->format('m/d/Y') }}"
+                                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5"
+                                    placeholder="Select sync start date" value="{{ request('sync_from', now()->subDay()->format('m/d/Y')) }}" required>
+                            </div>
+                        </div>
+                        <div class="mt-4 lg:mt-0">
+                            <label for="sync_to" class="block mb-2 text-sm font-medium text-gray-900">Sync To Date:</label>
+                            <div class="relative">
+                                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                                    <x-icons.date />
+                                </div>
+                                <input name="sync_to" id="sync_to" type="text" datepicker datepicker-format="mm/dd/yyyy" datepicker-max-date="{{ now()->format('m/d/Y') }}"
+                                    class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full ps-10 p-2.5"
+                                    placeholder="Select sync end date" value="{{ request('sync_to', now()->format('m/d/Y')) }}" required>
+                            </div>
+                        </div>
+                        <div class="flex items-center mt-4 lg:mt-0 gap-2 flex-wrap">
+                            <button type="submit"
+                                class="py-2.5 px-5 text-sm font-medium text-gray-900 focus:outline-none bg-white rounded-full border border-[#000000] hover:bg-[#00838f] hover:border-[#027480] hover:text-[#fff] focus:z-10 focus:ring-4 focus:ring-gray-100 flex gap-3 items-center justify-center w-full sm:w-[145px]">Sync Quotes</button>
+                        </div>
+                    </div>
+                    <p class="text-xs text-gray-500 mb-2">Select a date range to sync quote statuses from Syspro for this account.</p>
+                </form>
                 <div class="relative overflow-x-auto sm:rounded-2xl mt-5 md:mt-10" id="order_list">
                     <div id="accordion-collapse" data-accordion="collapse">
                         @if (!$quotes->isEmpty())

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,9 +52,20 @@ Route::get('/dashboard', function () {
 Route::middleware(['auth', 'verified.email'])->group(function () {
 
     Route::get('/run-history/{customer?}', function ($customer = null) {
-        Artisan::call('fetch:order-history', ['customer' => $customer]);
-        session()->flash('message', 'FetchOrderHistory job triggered successfully!');
-        return back(); 
+        $from = request('sync_from');
+        $to = request('sync_to');
+
+        $params = ['customer' => $customer];
+        if (!empty($from) && !empty($to)) {
+            $params['--from'] = $from;
+            $params['--to'] = $to;
+        }
+
+        Artisan::call('fetch:order-history', $params);
+        session()->flash('message', !empty($from) && !empty($to)
+            ? 'Orders synced for the selected date range.'
+            : 'FetchOrderHistory job triggered successfully!');
+        return back();
     })->name('sync-account');
 
 


### PR DESCRIPTION
Allow selecting From/To dates when syncing so Syspro statuses update for that range. Defaults to yesterday–today; search filters unchanged.